### PR TITLE
Feature/procps needed cassandra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG JAVA_VERSION=8
 ARG JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-oracle
 
 LABEL description="uBirch Maven build container"
-RUN apt-get update && apt-get --fix-missing install maven git -y && \
+RUN apt-get update && apt-get --fix-missing --no-install-recommends install procps maven git  -y && \
     apt-get autoclean && apt-get --purge -y autoremove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -29,8 +29,6 @@ RUN update-alternatives --install "/usr/bin/java" "java" "${JAVA_HOME}/bin/java"
     update-alternatives --set javac "${JAVA_HOME}/bin/javac"
 
 RUN git config --system user.name Docker && git config --system user.email docker@localhost
-
-RUN apt-get --yes --quiet update && apt-get --yes --quiet install procps
 
 RUN mkdir -p /build && mkdir -p /maven-repo
 VOLUME /build /maven-repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN update-alternatives --install "/usr/bin/java" "java" "${JAVA_HOME}/bin/java"
 
 RUN git config --system user.name Docker && git config --system user.email docker@localhost
 
+RUN apt-get --yes --quiet update && apt-get --yes --quiet install procps
+
 RUN mkdir -p /build && mkdir -p /maven-repo
 VOLUME /build /maven-repo
 WORKDIR /build


### PR DESCRIPTION
It has been identified that when running tests the pipeline breaks with the following error
After its corresponding research, it was found that the problem is due to a missing Linux tool called “kill” which prevents from stopping Cassandra, which ends up in a loop of problems when trying to start Cassandra anew. 
**Bottom line**: Tests fail because the build docker image doesn't have procps installed.

This PR fixes that issue by installing the needed package. 